### PR TITLE
Fixed #32 - Make installation easier by executing one artisan command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,37 +26,14 @@ Bagisto GDPR will help customers to Send Data Requests for Changing name , email
 
 ## 3. Installation:
 
-### Install with composer
-Go to the root folder of **Bagisto** and run the following command:
+Go to the root folder of **Bagisto** and run the following commands:
 
 ```
 composer require bagisto/bagisto-gdpr
 ```
 
-Prepare your database table(s) by the following command:
 ```
-php artisan migrate
-```
-
-Populate the table(s)
-```
-php artisan db:seed --class=Webkul\\GDPR\\Database\\Seeders\\GdprTableSeeder
-```
-
-#### Run these commands below to complete the setup
-
-```
-php artisan route:clear
-```
-
-```
-php artisan config:cache
-```
-
-```
-php artisan vendor:publish
-
--> Press 0 and then press enter to publish all assets and configurations.
+php artisan gdpr:install
 ```
 
 * Enable the GDPR Module from the Admin Panel
@@ -64,57 +41,3 @@ php artisan vendor:publish
 ```
 Admin->Settings->GDPR
 ```
-
-### Install without composer
-* Unzip the respective extension zip and then create a folder named **GDPR**  inside the `packages/Webkul` folder into project root directory.
-* Goto config/app.php file and add following line under 'providers'
-
-```php
-Webkul\GDPR\Providers\GDPRServiceProvider::class
-```
-
-* Goto composer.json file and add following line under 'psr-4'
-
-```json
-"Webkul\\GDPR\\": "packages/Webkul/GDPR/src"
-```
-Now run the following command:
-```
-composer dump-autoload
-```
-
-Prepare your database table(s) by the following command:
-```
-php artisan migrate
-```
-
-Populate the table(s)
-```
-php artisan db:seed --class=Webkul\\GDPR\\Database\\Seeders\\GdprTableSeeder
-```
-
-#### Run these commands below to complete the setup
-
-```
-php artisan route:clear
-```
-
-```
-php artisan config:cache
-```
-
-```
-php artisan vendor:publish
-
--> Press 0 and then press enter to publish all assets and configurations.
-```
-
-* Enable the GDPR Module from the Admin Panel
- 
-```
-Admin->Settings->GDPR
-```
-
-
-
-> That's it, now just execute the project on your specified domain.

--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Webkul\GDPR\Console\Commands;
+
+use Illuminate\Console\Command;
+use Artisan;
+
+class Install extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'gdpr:install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'This will prepare the GDPR package';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        Artisan::call('migrate');
+        Artisan::call('db:seed --class=Webkul\\GDPR\\Database\\Seeders\\GdprTableSeeder');
+        Artisan::call('route:optimize');
+        Artisan::call('vendor:publish --provider="Bagisto\GDPR\Providers\GDPRServiceProvider" --force');
+    }
+}

--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -39,8 +39,14 @@ class Install extends Command
     public function handle()
     {
         Artisan::call('migrate');
-        Artisan::call('db:seed --class=Webkul\\GDPR\\Database\\Seeders\\GdprTableSeeder');
-        Artisan::call('route:optimize');
-        Artisan::call('vendor:publish --provider="Bagisto\GDPR\Providers\GDPRServiceProvider" --force');
+        Artisan::call('db:seed', [
+            '--class' => "Webkul\\GDPR\\Database\\Seeders\\GdprTableSeeder"
+        ]);
+
+        Artisan::call('optimize');
+        Artisan::call('vendor:publish', [
+            '--provider' => "Webkul\GDPR\Providers\GDPRServiceProvider",
+            '--force'    => true
+        ]);
     }
 }

--- a/src/Providers/GDPRServiceProvider.php
+++ b/src/Providers/GDPRServiceProvider.php
@@ -1,14 +1,18 @@
 <?php
+
 namespace Webkul\GDPR\Providers;
 
 use Webkul\Core\Tree;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Event;
+
 use Illuminate\Support\Facades\DB;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
 
-    class GDPRServiceProvider extends ServiceProvider
+use Webkul\GDPR\Console\Commands\Install;
+
+class GDPRServiceProvider extends ServiceProvider
     {
         /**
         * Bootstrap services.
@@ -46,6 +50,12 @@ use Illuminate\Support\ServiceProvider;
             ]);
 
             $this->app->register(RepositoryServiceProvider::class);
+
+            if ($this->app->runningInConsole()) {
+                $this->commands([
+                    Install::class,
+                ]);
+            }
         }
 
         /**
@@ -61,7 +71,7 @@ use Illuminate\Support\ServiceProvider;
         protected function registerConfig()
         {
             try{
-                    $gdpr = DB::table('gdpr')->select('gdpr_status')->get(); 
+                    $gdpr = DB::table('gdpr')->select('gdpr_status')->get();
                     if($gdpr['0']->gdpr_status == 1)
                     {
                         $this->mergeConfigFrom(
@@ -71,14 +81,14 @@ use Illuminate\Support\ServiceProvider;
                         $this->mergeConfigFrom(
                             dirname(__DIR__) . '/Config/admin-menu.php', 'menu.admin'
                         );
-                    }  
+                    }
             }catch (\Exception $e){
 
                 $this->mergeConfigFrom(
                     dirname(__DIR__) . '/Config/admin-menu.php', 'menu.admin'
                 );
-                
-            }  
-            
+
+            }
+
         }
     }


### PR DESCRIPTION
fixed #32 
- Added a console command `php artisan gdpr:install` that does all previous installation steps automatically.